### PR TITLE
Clear session and reload when 401

### DIFF
--- a/src/app/dm-viewer/dm-viewer.component.spec.ts
+++ b/src/app/dm-viewer/dm-viewer.component.spec.ts
@@ -179,4 +179,23 @@ describe('DmViewerComponent', () => {
 
   });
 
+  describe('when the server returns a 401 error', () => {
+    beforeEach(() => {
+      spyOn(sessionService, 'clearSession');
+
+      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const mockErrorResponse = {
+        status: 401, statusText: 'Unauthorized'
+      };
+      const data = 'Invalid request parameters';
+      req.flush(data, mockErrorResponse);
+      fixture.detectChanges();
+    });
+
+    it('should clear the local session and reload', () => {
+      expect(sessionService.clearSession).toHaveBeenCalled();
+    });
+
+  });
+
 });

--- a/src/app/dm-viewer/dm-viewer.component.ts
+++ b/src/app/dm-viewer/dm-viewer.component.ts
@@ -44,6 +44,10 @@ export class DmViewerComponent implements OnInit {
           }
         },
         err => {
+          if (err.status === 401) {
+            this.sessionService.clearSession();
+            return;
+          }
           this.error = err;
         });
   }


### PR DESCRIPTION
If the token has expired or is incorrect, clear the local cookie and reload the page.