### PR TITLE
Do not include jwt so we do not redirect

### DIFF
--- a/src/app/dm-viewer/dm-viewer.component.spec.ts
+++ b/src/app/dm-viewer/dm-viewer.component.spec.ts
@@ -67,7 +67,7 @@ describe('DmViewerComponent', () => {
 
   describe('when the mime type is an image', () => {
     beforeEach(() => {
-      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const req = httpMock.expectOne(url);
       req.flush({
         mimeType: 'image/jpeg',
         originalDocumentName: 'image.jpeg',
@@ -95,7 +95,7 @@ describe('DmViewerComponent', () => {
 
   describe('when the mime type is pdf', () => {
     beforeEach(() => {
-      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const req = httpMock.expectOne(url);
       req.flush({
         mimeType: 'application/pdf',
         originalDocumentName: 'cert.pdf',
@@ -123,7 +123,7 @@ describe('DmViewerComponent', () => {
 
   describe('when the mime type is unsupported', () => {
     beforeEach(() => {
-      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const req = httpMock.expectOne(url);
       req.flush({
         mimeType: 'text/plain',
         originalDocumentName: 'plain.txt',
@@ -156,7 +156,7 @@ describe('DmViewerComponent', () => {
 
   describe('when the server returns an error', () => {
     beforeEach(() => {
-      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const req = httpMock.expectOne(url);
       const mockErrorResponse = {
         status: 404, statusText: 'Not Found'
       };
@@ -183,7 +183,7 @@ describe('DmViewerComponent', () => {
     beforeEach(() => {
       spyOn(sessionService, 'clearSession');
 
-      const req = httpMock.expectOne(`${url}?jwt=${jwt}`);
+      const req = httpMock.expectOne(url);
       const mockErrorResponse = {
         status: 401, statusText: 'Unauthorized'
       };

--- a/src/app/dm-viewer/dm-viewer.component.ts
+++ b/src/app/dm-viewer/dm-viewer.component.ts
@@ -34,7 +34,7 @@ export class DmViewerComponent implements OnInit {
     const httpOptions = {
       headers: new HttpHeaders({ 'Authorization': `Bearer ${this.jwt}` })
     };
-    this.http.get<any>(`${this.url}?jwt=${this.jwt}`, httpOptions)
+    this.http.get<any>(`${this.url}`, httpOptions)
       .subscribe(
         resp => {
           if (resp && resp._links) {


### PR DESCRIPTION
Firefox doesn't read the CORS headers on responses that aren't 2xx or 4xx so when the gateway returns 302 after reading the jwt it just soils itself and returns a completely opaque error message.

We already set the authorisation header when getting the metadata and binary for both images and pdfs so we should be good without it setting the cookie.