### PR TITLE
Annotations

### DIFF
--- a/src/app/app.config.spec.ts
+++ b/src/app/app.config.spec.ts
@@ -1,0 +1,31 @@
+import {AppConfig} from './app.config';
+import {async, TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+
+describe('AppConfig tests', () => {
+  let httpMock: HttpTestingController;
+  let appConfig: AppConfig;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [],
+      providers: [AppConfig]
+    }).compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    httpMock = TestBed.get(HttpTestingController);
+    appConfig = TestBed.get(AppConfig);
+    appConfig.load();
+    const request = httpMock.expectOne(AppConfig.CONFIG_PATH);
+    request.flush({
+      'annotation_url': 'http://localhost:8086/annotation-sets'
+    });
+  }));
+
+  it('should load annotation url', () => {
+    expect(appConfig.getAnnotationUrl()).toEqual('http://localhost:8086/annotation-sets');
+  });
+
+});

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,6 +3,7 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
+import {HttpClient} from '@angular/common/http';
 
 @Injectable()
 export class AppConfig {
@@ -11,7 +12,7 @@ export class AppConfig {
 
   private config: Config;
 
-  constructor(private http: Http) {}
+  constructor(private http: HttpClient) {}
 
   public load(): Promise<void> {
     console.log('Loading app config...');
@@ -19,17 +20,15 @@ export class AppConfig {
     return new Promise<void>((resolve, reject) => {
       this.http
         .get(AppConfig.CONFIG_PATH)
-        .map(response => response.json())
-        .catch((error: any): any => {
-          console.error('Configuration file "config.json" could not be read');
-          reject();
-          return Observable.throw(error.json().error || 'Server error');
-        })
-        .subscribe((config: Config) => {
-          this.config = config;
-          console.log('Loading app config: OK');
-          resolve();
-        });
+          .subscribe((config: Config) => {
+            this.config = config;
+            console.log('Loading app config: OK');
+            resolve();
+          }, error => {
+            console.error('Configuration file "config.json" could not be read');
+            reject();
+            return Observable.throw(error.json().error || 'Server error');
+          });
     });
   }
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,7 +8,7 @@ import {HttpClient} from '@angular/common/http';
 @Injectable()
 export class AppConfig {
 
-  private static readonly CONFIG_PATH = '/assets/config.json';
+  public static readonly CONFIG_PATH = '/assets/config.json';
 
   private config: Config;
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -37,8 +37,12 @@ export class AppConfig {
     return this.config.login_url;
   }
 
+  getAnnotationUrl() {
+    return this.config.annotation_url;
+  }
 }
 
 export class Config {
   login_url: string;
+  annotation_url: string;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { UnsupportedViewerComponent } from './dm-viewer/unsupported-viewer/unsup
 import {ViewerFactoryService} from './dm-viewer/viewer-factory.service';
 import { NotesComponent } from './dm-viewer/notes/notes.component';
 import {ImagePipe} from './utils/image-pipe';
+import {AnnotationService} from './dm-viewer/annotations/annotation.service';
 
 const appRoutes: Routes = [
   { path: ':url', canActivate: [IdamGuard], component: DmViewerComponent },
@@ -61,6 +62,7 @@ const appRoutes: Routes = [
     SessionService,
     CookieService,
     ViewerFactoryService,
+    AnnotationService,
     AppConfig,
     { provide: APP_INITIALIZER, useFactory: (config: AppConfig) => () => config.load(), deps: [AppConfig], multi: true }
   ],

--- a/src/app/dm-viewer/annotations/annotation.service.ts
+++ b/src/app/dm-viewer/annotations/annotation.service.ts
@@ -1,0 +1,51 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {AppConfig} from '../../app.config';
+import {SessionService} from '../../auth/session.service';
+
+export class Note {
+  content: string;
+  uuid: string;
+  page: number;
+
+
+  constructor(content: string = '', uuid: string = '', page: number = 1) {
+    this.content = content;
+    this.uuid = uuid;
+    this.page = page;
+  }
+}
+
+@Injectable()
+export class AnnotationService {
+  constructor(private httpClient: HttpClient,
+              private sessionService: SessionService,
+              private appConfig: AppConfig) {
+  }
+
+  getNotes(url): Promise<Note[]> {
+    return new Promise((resolve, reject) => {
+      const httpOptions = {
+        headers: new HttpHeaders({
+          'Authorization': `Bearer ${this.sessionService.getSession().token}`,
+          'Accept': 'application/json'
+        })
+      };
+      const annoUrl = `${this.appConfig.getAnnotationUrl()}/find-all-by-document-url?url=${url}`;
+      this.httpClient.get<any>(annoUrl, httpOptions).subscribe(response => {
+        if (response._embedded.annotationSets && response._embedded.annotationSets.length) {
+          const set = response._embedded.annotationSets[0];
+          const notes = set.annotations
+            .filter(annotation => annotation.type === 'PAGENOTE')
+            .sort((a, b) => a.page - b.page)
+            .map(annotation => {
+              return new Note(annotation.comments[0].content, annotation.page, annotation.uuid);
+            });
+          resolve(notes);
+        }
+        resolve(new Array<Note>());
+      }, reject);
+    });
+  }
+
+}

--- a/src/app/dm-viewer/dm-viewer.component.html
+++ b/src/app/dm-viewer/dm-viewer.component.html
@@ -16,6 +16,7 @@
 
 <app-notes *ngIf="annotate && viewerComponent && viewerComponent.numPages > 0"
            class="notes"
+           [url]="url"
            [page]="viewerComponent.page"
            [numPages]="viewerComponent.numPages">
 </app-notes>

--- a/src/app/dm-viewer/notes/notes.component.spec.ts
+++ b/src/app/dm-viewer/notes/notes.component.spec.ts
@@ -109,21 +109,21 @@ describe('NotesComponent', () => {
             annotations: [{
               uuid: '',
               page: 2,
-              type: "PAGENOTE",
+              type: 'PAGENOTE',
               comments: [{
                 content: 'Page 2 note'
               }]
             }, {
               uuid: '',
               page: 1,
-              type: "PAGENOTE",
+              type: 'PAGENOTE',
               comments: [{
                 content: 'Page 1 note'
               }]
             }, {
               uuid: '',
               page: 1,
-              type: "COMMENT",
+              type: 'COMMENT',
               comments: [{
                 content: 'Page 1 comment'
               }]

--- a/src/app/dm-viewer/notes/notes.component.spec.ts
+++ b/src/app/dm-viewer/notes/notes.component.spec.ts
@@ -1,25 +1,40 @@
-import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
 
-import { NotesComponent } from './notes.component';
+import {NotesComponent} from './notes.component';
 import {DebugElement} from '@angular/core';
-import {By} from '@angular/platform-browser';
+import {AnnotationService} from '../annotations/annotation.service';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {SessionService} from '../../auth/session.service';
+import {CookieService} from 'angular2-cookie/core';
+import {WindowService} from '../../utils/window.service';
+import {AppConfig} from '../../app.config';
+
+const jwt = '12345';
 
 describe('NotesComponent', () => {
   let component: NotesComponent;
   let element: DebugElement;
   let fixture: ComponentFixture<NotesComponent>;
+  let httpMock: HttpTestingController;
+  let sessionService: SessionService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ NotesComponent ],
-      imports: [ FormsModule ]
+      imports: [ FormsModule, HttpClientTestingModule ],
+      providers: [ AnnotationService, SessionService, WindowService, CookieService, AppConfig ]
     })
     .compileComponents();
   }));
 
   beforeEach(async(() => {
+    sessionService = TestBed.get(SessionService);
+    sessionService.createSession({
+      token: jwt
+    });
     fixture = TestBed.createComponent(NotesComponent);
+    httpMock = TestBed.get(HttpTestingController);
     component = fixture.componentInstance;
     element = fixture.debugElement;
     component.page = 0;

--- a/src/app/dm-viewer/notes/notes.component.spec.ts
+++ b/src/app/dm-viewer/notes/notes.component.spec.ts
@@ -18,14 +18,16 @@ describe('NotesComponent', () => {
   let fixture: ComponentFixture<NotesComponent>;
   let httpMock: HttpTestingController;
   let sessionService: SessionService;
+  let appConfig: AppConfig;
+  const val = 'https://anno-url/annotations';
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NotesComponent ],
-      imports: [ FormsModule, HttpClientTestingModule ],
-      providers: [ AnnotationService, SessionService, WindowService, CookieService, AppConfig ]
+      declarations: [NotesComponent],
+      imports: [FormsModule, HttpClientTestingModule],
+      providers: [AnnotationService, SessionService, WindowService, CookieService, AppConfig]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(async(() => {
@@ -35,56 +37,71 @@ describe('NotesComponent', () => {
     });
     fixture = TestBed.createComponent(NotesComponent);
     httpMock = TestBed.get(HttpTestingController);
+    appConfig = TestBed.get(AppConfig);
+    spyOn(appConfig, 'getAnnotationUrl').and.returnValue(val);
     component = fixture.componentInstance;
     element = fixture.debugElement;
     component.page = 0;
+    component.url = 'https://doc123';
     fixture.detectChanges();
   }));
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  beforeEach(() => {
   });
 
-  it('should initialise to page 0', () => {
-    expect(component.page).toEqual(0);
-  });
-
-  it('should default to 0 pages', () => {
-    expect(component.numPages).toEqual(0);
-  });
-
-  describe('when there is a note against the current page', () => {
+  describe('when no notes are loaded', () => {
     beforeEach(() => {
-      component.currentNote = 'A note';
+      const req = httpMock.expectOne('https://anno-url/annotations/find-all-by-document-url?url=https://doc123');
+      req.flush({
+        _embedded: {
+          annotationSets: []
+        }
+      });
       fixture.detectChanges();
     });
 
-    describe('and we swap to the next page', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialise to page 0', () => {
+      expect(component.page).toEqual(0);
+    });
+
+    it('should default to 0 pages', () => {
+      expect(component.numPages).toEqual(0);
+    });
+
+    describe('when there is a note against the current page', () => {
       beforeEach(() => {
-        component.page = 1;
+        component.currentNote = 'A note';
         fixture.detectChanges();
       });
 
-      it('should update the current note to a blank note', () => {
-        expect(component.currentNote).toEqual('');
-      });
-
-      describe('when we swap back to the previous page', () => {
+      describe('and we swap to the next page', () => {
         beforeEach(() => {
-          component.page = 0;
+          component.page = 1;
           fixture.detectChanges();
         });
 
-        it('should update the current note to the first page note', () => {
-          expect(component.currentNote).toEqual('A note');
+        it('should update the current note to a blank note', () => {
+          expect(component.currentNote).toEqual('');
         });
 
+        describe('when we swap back to the previous page', () => {
+          beforeEach(() => {
+            component.page = 0;
+            fixture.detectChanges();
+          });
 
+          it('should update the current note to the first page note', () => {
+            expect(component.currentNote).toEqual('A note');
+          });
+        });
       });
-
     });
-
   });
+
 
   function newEvent(eventName: string, bubbles = false, cancelable = false) {
     const evt = document.createEvent('CustomEvent');  // MUST be 'CustomEvent'

--- a/src/app/dm-viewer/notes/notes.component.spec.ts
+++ b/src/app/dm-viewer/notes/notes.component.spec.ts
@@ -41,13 +41,9 @@ describe('NotesComponent', () => {
     spyOn(appConfig, 'getAnnotationUrl').and.returnValue(val);
     component = fixture.componentInstance;
     element = fixture.debugElement;
-    component.page = 0;
     component.url = 'https://doc123';
     fixture.detectChanges();
   }));
-
-  beforeEach(() => {
-  });
 
   describe('when no notes are loaded', () => {
     beforeEach(() => {
@@ -57,6 +53,7 @@ describe('NotesComponent', () => {
           annotationSets: []
         }
       });
+      component.page = 0;
       fixture.detectChanges();
     });
 
@@ -101,6 +98,53 @@ describe('NotesComponent', () => {
       });
     });
   });
+
+  describe('when notes are loaded', () => {
+    beforeEach(async(() => {
+      const req = httpMock.expectOne('https://anno-url/annotations/find-all-by-document-url?url=https://doc123');
+      req.flush({
+        _embedded: {
+          annotationSets: [{
+            uuid: '',
+            annotations: [{
+              uuid: '',
+              page: 2,
+              type: "PAGENOTE",
+              comments: [{
+                content: 'Page 2 note'
+              }]
+            }, {
+              uuid: '',
+              page: 1,
+              type: "PAGENOTE",
+              comments: [{
+                content: 'Page 1 note'
+              }]
+            }, {
+              uuid: '',
+              page: 1,
+              type: "COMMENT",
+              comments: [{
+                content: 'Page 1 comment'
+              }]
+            }]
+          }]
+        }
+      });
+      fixture.detectChanges();
+    }));
+
+    it('should filter out the non page note annotations', () => {
+      expect(component.notes.length).toBe(2);
+    });
+
+    it('should update the current note to the loaded note', () => {
+      expect(component.currentNote).toEqual('Page 1 note');
+    });
+
+
+  });
+
 
 
   function newEvent(eventName: string, bubbles = false, cancelable = false) {

--- a/src/app/dm-viewer/notes/notes.component.ts
+++ b/src/app/dm-viewer/notes/notes.component.ts
@@ -8,7 +8,7 @@ import {AnnotationService, Note} from '../annotations/annotation.service';
 })
 export class NotesComponent implements OnInit {
 
-  private _page = 0;
+  private _page = 1;
 
   @Input() numPages = 0;
   @Input() url;

--- a/src/app/dm-viewer/notes/notes.component.ts
+++ b/src/app/dm-viewer/notes/notes.component.ts
@@ -27,12 +27,10 @@ export class NotesComponent implements OnInit {
 
   @Input() set page(value: number) {
     this._page = value;
-    if (this.notes) {
-      if (!this.notes[this._page - 1]) {
-        this.notes[this._page - 1] = new Note();
-      }
-      this.currentNote = this.notes[this._page - 1].content;
+    if (!this.notes[this._page - 1]) {
+      this.notes[this._page - 1] = new Note();
     }
+    this.currentNote = this.notes[this._page - 1].content;
   }
 
   get page(): number {

--- a/src/app/dm-viewer/notes/notes.component.ts
+++ b/src/app/dm-viewer/notes/notes.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
+import {AnnotationService, Note} from '../annotations/annotation.service';
 
 @Component({
   selector: 'app-notes',
@@ -10,22 +11,27 @@ export class NotesComponent implements OnInit {
   private _page = 0;
 
   @Input() numPages = 0;
+  @Input() url;
 
-  notes = [];
+  notes: Note[] = [];
   private _currentNote = '';
 
-  constructor() { }
+  constructor(private annotationService: AnnotationService) { }
 
   ngOnInit() {
+    this.annotationService.getNotes(this.url).then(notes => {
+      this.notes = notes;
+      this.page = this._page;
+    }).catch(console.log);
   }
 
   @Input() set page(value: number) {
     this._page = value;
     if (this.notes) {
       if (!this.notes[this._page - 1]) {
-        this.notes[this._page - 1] = '';
+        this.notes[this._page - 1] = new Note();
       }
-      this.currentNote = this.notes[this._page - 1];
+      this.currentNote = this.notes[this._page - 1].content;
     }
   }
 
@@ -35,7 +41,7 @@ export class NotesComponent implements OnInit {
 
   set currentNote(value: string) {
     this._currentNote = value;
-    this.notes[this._page - 1] = this._currentNote;
+    this.notes[this._page - 1].content = this._currentNote;
   }
 
   get currentNote(): string {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,3 +1,4 @@
 {
-  "login_url": "https://localhost:9000/login"
+  "login_url": "https://localhost:9000/login",
+  "annotation_url": "http://localhost:8086/annotation-sets"
 }


### PR DESCRIPTION
Load existing page notes when you open up a document and have `annotate=true` query parameter.

Currently you have to add the notes manually through the annotation app rest API. Saving new notes is the next feature to build!
