### PR TITLE
Re-write internal urls

### DIFF
--- a/src/app/em-annotation-summary/em-annotation-summary.component.spec.ts
+++ b/src/app/em-annotation-summary/em-annotation-summary.component.spec.ts
@@ -8,7 +8,7 @@ import {EmAnnotationSummaryModule} from './em-annotation-summary.module';
 
 const documentUrl = 'http://api-gateway.dm.com/documents/1234-1234-1234';
 const annotationUrl = '';
-const findAnnotationUrl = annotationUrl + '/find-all-by-document-url?url=' + documentUrl;
+const findAnnotationUrl = '/demproxy/dm/find-all-by-document-url?url=' + documentUrl;
 
 const configObject = {
   'annotation_url' : annotationUrl

--- a/src/app/em-annotation-summary/em-annotation-summary.component.ts
+++ b/src/app/em-annotation-summary/em-annotation-summary.component.ts
@@ -53,7 +53,7 @@ export class EmAnnotationSummaryComponent implements OnInit {
 
   private lookForAnnotationSets(): Promise<any> {
     return new Promise((resolve, reject) => {
-      const annoUrl = `/find-all-by-document-url?url=${this.url}`;
+      const annoUrl = `/demproxy/dm/find-all-by-document-url?url=${this.url}`;
       this.http.get<any>(annoUrl, this.httpOptions()).subscribe(response => {
         if (response._embedded && response._embedded.annotationSets && response._embedded.annotationSets.length) {
           resolve(response._embedded.annotationSets[0]);

--- a/src/app/em-viewer/annotations/notes/notes.component.spec.ts
+++ b/src/app/em-viewer/annotations/notes/notes.component.spec.ts
@@ -7,6 +7,7 @@ import {AnnotationService, Note} from '../annotation.service';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {CookieModule} from 'ngx-cookie';
 import {AppConfig} from '../../../app.config';
+import {UrlFixerService} from '../../../utils/url-fixer.service';
 
 const jwt = '12345';
 
@@ -15,14 +16,13 @@ describe('NotesComponent', () => {
   let element: DebugElement;
   let fixture: ComponentFixture<NotesComponent>;
   let httpMock: HttpTestingController;
-  let appConfig: AppConfig;
-  const val = 'https://anno-url/annotation-sets';
+  const val = '/demproxy/an/annotation-sets';
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [NotesComponent],
       imports: [FormsModule, HttpClientTestingModule, CookieModule.forRoot()],
-      providers: [AnnotationService, AppConfig]
+      providers: [AnnotationService, UrlFixerService]
     })
       .compileComponents();
   }));
@@ -30,8 +30,6 @@ describe('NotesComponent', () => {
   beforeEach(async(() => {
     fixture = TestBed.createComponent(NotesComponent);
     httpMock = TestBed.get(HttpTestingController);
-    appConfig = TestBed.get(AppConfig);
-    spyOn(appConfig, 'getAnnotationUrl').and.returnValue(val);
     component = fixture.componentInstance;
     element = fixture.debugElement;
     component.url = 'https://doc123';
@@ -40,7 +38,7 @@ describe('NotesComponent', () => {
 
   describe('when no notes are loaded', () => {
     beforeEach(() => {
-      const req = httpMock.expectOne('https://anno-url/annotation-sets/find-all-by-document-url?url=https://doc123');
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/find-all-by-document-url?url=https://doc123');
       req.flush({
         _embedded: {
           annotationSets: []
@@ -94,7 +92,7 @@ describe('NotesComponent', () => {
 
   describe('when notes are loaded', () => {
     beforeEach(async(() => {
-      const req = httpMock.expectOne('https://anno-url/annotation-sets/find-all-by-document-url?url=https://doc123');
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/find-all-by-document-url?url=https://doc123');
       req.flush({
         _embedded: {
           annotationSets: [{
@@ -108,7 +106,7 @@ describe('NotesComponent', () => {
               }],
               '_links': {
                 self: {
-                  href: 'https://anno-url/annotation-sets/1234/annotation/1'
+                  href: 'http://test.com/annotation-sets/1234/annotation/1'
                 }
               }
             }, {
@@ -120,7 +118,7 @@ describe('NotesComponent', () => {
               }],
               '_links': {
                 self: {
-                  href: 'https://anno-url/annotation-sets/1234/annotation/2'
+                  href: 'http://test.com/annotation-sets/1234/annotation/2'
                 }
               }
             }, {
@@ -132,16 +130,16 @@ describe('NotesComponent', () => {
               }],
               '_links': {
                 self: {
-                  href: 'https://anno-url/annotation-sets/1234/annotation/3'
+                  href: 'http://test.com/annotation-sets/1234/annotation/3'
                 }
               }
             }],
             '_links': {
               self: {
-                href: 'https://anno-url/annotation-sets/1234'
+                href: 'http://test.com/annotation-sets/1234'
               },
               'add-annotation': {
-                href: 'https://anno-url/annotation-sets/1234/annotation'
+                href: 'http://test.com/annotation-sets/1234/annotation'
               }
             }
           }]
@@ -167,7 +165,7 @@ describe('NotesComponent', () => {
         fixture.detectChanges();
         component.save();
 
-        putRequest = httpMock.expectOne('https://anno-url/annotation-sets/1234/annotation/2');
+        putRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
         putRequest.flush({}, {status: 200, statusText: 'Good!'});
       }));
 
@@ -189,7 +187,7 @@ describe('NotesComponent', () => {
         fixture.detectChanges();
         component.clear();
 
-        putRequest = httpMock.expectOne('https://anno-url/annotation-sets/1234/annotation/2');
+        putRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
         putRequest.flush({
           uuid: '1',
           page: 1,
@@ -199,7 +197,7 @@ describe('NotesComponent', () => {
           }],
           '_links': {
             self: {
-              href: 'https://anno-url/annotation-sets/1234/annotation/1'
+              href: 'http://test.com/annotation-sets/1234/annotation/1'
             }
           }
         });
@@ -220,12 +218,12 @@ describe('NotesComponent', () => {
 
     beforeEach(async(() => {
       component.currentNote.content = '';
-      component.currentNote.url = 'https://anno-url/annotation-sets/1234/annotation/2';
+      component.currentNote.url = '/demproxy/an/annotation-sets/1234/annotation/2';
       component.notesForm.form.markAsDirty();
       fixture.detectChanges();
       component.save();
 
-      deleteRequest = httpMock.expectOne('https://anno-url/annotation-sets/1234/annotation/2');
+      deleteRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
       deleteRequest.flush({}, {status: 200, statusText: 'Good!'});
     }));
 
@@ -244,22 +242,22 @@ describe('NotesComponent', () => {
 
   describe('when we try and load notes but we have no sets', () => {
     beforeEach(async(() => {
-      const req = httpMock.expectOne('https://anno-url/annotation-sets/find-all-by-document-url?url=https://doc123');
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/find-all-by-document-url?url=https://doc123');
       req.flush({});
       fixture.detectChanges();
     }));
 
     beforeEach(async(() => {
-      const postReq = httpMock.expectOne('https://anno-url/annotation-sets');
+      const postReq = httpMock.expectOne('/demproxy/an/annotation-sets');
       postReq.flush({
         uuid: '1234',
           annotations: [],
           '_links': {
           self: {
-            href: 'https://anno-url/annotation-sets/1234'
+            href: 'http://test.com/annotation-sets/1234'
           },
           'add-annotation': {
-            href: 'https://anno-url/annotation-sets/1234/annotation'
+            href: 'http://test.com/annotation-sets/1234/annotation'
           }
         }
       });
@@ -275,7 +273,7 @@ describe('NotesComponent', () => {
         component.currentNote.content = 'A really great note';
         fixture.detectChanges();
         component.save();
-        const postReq = httpMock.expectOne('https://anno-url/annotation-sets/1234/annotation');
+        const postReq = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation');
         postReq.flush({
           uuid: '1',
           page: 1,
@@ -285,14 +283,14 @@ describe('NotesComponent', () => {
           }],
           '_links': {
             self: {
-              href: 'https://anno-url/annotation-sets/1234/annotation/1'
+              href: 'http://test.com/annotation-sets/1234/annotation/1'
             }
           }
         });
       }));
 
       it('should update the note with the generated url', () => {
-        expect(component.currentNote.url).toEqual('https://anno-url/annotation-sets/1234/annotation/1');
+        expect(component.currentNote.url).toEqual('/demproxy/an/annotation-sets/1234/annotation/1');
       });
     });
 
@@ -301,7 +299,7 @@ describe('NotesComponent', () => {
         component.currentNote.content = 'A rubbish note';
         fixture.detectChanges();
         component.clear();
-        const postReq = httpMock.expectNone('https://anno-url/annotation-sets/1234/annotation');
+        const postReq = httpMock.expectNone('/demproxy/an/annotation-sets/1234/annotation');
       }));
 
       it('should update the note with the generated url', () => {

--- a/src/app/em-viewer/em-viewer.component.spec.ts
+++ b/src/app/em-viewer/em-viewer.component.spec.ts
@@ -5,7 +5,8 @@ import {HttpClientTestingModule, HttpTestingController} from '@angular/common/ht
 import {DebugElement} from '@angular/core';
 import {EmViewerModule} from './em-viewer.module';
 
-const url = 'http://api-gateway.dm.com/documents/1234-1234-1234';
+const originalUrl = 'http://api-gateway.dm.com/documents/1234-1234-1234';
+const url = '/demproxy/dm/documents/1234-1234-1234';
 
 describe('DmViewerComponent', () => {
   let component: EmViewerComponent;
@@ -25,7 +26,7 @@ describe('DmViewerComponent', () => {
     httpMock = TestBed.get(HttpTestingController);
     fixture = TestBed.createComponent(EmViewerComponent);
     component = fixture.componentInstance;
-    component.url = url;
+    component.url = originalUrl;
     element = fixture.debugElement;
     fixture.detectChanges();
   });
@@ -38,7 +39,7 @@ describe('DmViewerComponent', () => {
         originalDocumentName: 'image.jpeg',
         _links: {
           binary: {
-            href: `${url}/binary`
+            href: `${originalUrl}/binary`
           }
         }
       });
@@ -66,7 +67,7 @@ describe('DmViewerComponent', () => {
         originalDocumentName: 'cert.pdf',
         _links: {
           binary: {
-            href: `${url}/binary`
+            href: `${originalUrl}/binary`
           }
         }
       });
@@ -94,7 +95,7 @@ describe('DmViewerComponent', () => {
         originalDocumentName: 'plain.txt',
         _links: {
           binary: {
-            href: `${url}/binary`
+            href: `${originalUrl}/binary`
           }
         }
       });

--- a/src/app/em-viewer/em-viewer.component.ts
+++ b/src/app/em-viewer/em-viewer.component.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@angular/common/http';
 import {ViewerAnchorDirective} from './viewers/viewer-anchor.directive';
 import {ViewerFactoryService} from './viewers/viewer-factory.service';
 import {Viewer} from './viewers/viewer';
+import {UrlFixerService} from '../utils/url-fixer.service';
 
 @Component({
   selector: 'app-em-viewer',
@@ -21,13 +22,14 @@ export class EmViewerComponent implements OnInit {
   error: string;
 
   constructor(private http: HttpClient,
+              private urlFixer: UrlFixerService,
               private viewerFactoryService: ViewerFactoryService) { }
 
   ngOnInit() {
     if (!this.url) {
       throw new Error('url is a required arguments');
     }
-    this.http.get<any>(`${this.url}`, {})
+    this.http.get<any>(`${this.urlFixer.fixDm(this.url)}`, {})
       .subscribe(
         resp => {
           if (resp && resp._links) {

--- a/src/app/em-viewer/em-viewer.module.ts
+++ b/src/app/em-viewer/em-viewer.module.ts
@@ -13,6 +13,7 @@ import {UnsupportedViewerComponent} from './viewers/unsupported-viewer/unsupport
 import {NotesComponent} from './annotations/notes/notes.component';
 import {ImgViewerComponent} from './viewers/img-viewer/img-viewer.component';
 import {ViewerAnchorDirective} from './viewers/viewer-anchor.directive';
+import {UrlFixerService} from '../utils/url-fixer.service';
 
 @NgModule({
   declarations: [
@@ -38,7 +39,8 @@ import {ViewerAnchorDirective} from './viewers/viewer-anchor.directive';
   ],
   providers: [
     ViewerFactoryService,
-    AnnotationService
+    AnnotationService,
+    UrlFixerService
   ],
 })
 export class EmViewerModule {

--- a/src/app/em-viewer/viewers/viewer-factory.service.ts
+++ b/src/app/em-viewer/viewers/viewer-factory.service.ts
@@ -3,6 +3,7 @@ import { PdfViewerComponent} from './pdf-viewer/pdf-viewer.component';
 import { ImgViewerComponent} from './img-viewer/img-viewer.component';
 import {Viewer} from './viewer';
 import {UnsupportedViewerComponent} from './unsupported-viewer/unsupported-viewer.component';
+import {UrlFixerService} from '../../utils/url-fixer.service';
 
 @Injectable()
 export class ViewerFactoryService {
@@ -25,7 +26,8 @@ export class ViewerFactoryService {
     return mimeType === 'application/pdf';
   }
 
-  constructor(private componentFactoryResolver: ComponentFactoryResolver) { }
+  constructor(private componentFactoryResolver: ComponentFactoryResolver,
+              private urlFixer: UrlFixerService) { }
 
   buildViewer(documentMetaData, viewContainerRef: ViewContainerRef) {
     const componentToBuild =
@@ -36,7 +38,7 @@ export class ViewerFactoryService {
     viewContainerRef.clear();
 
     const componentRef: ComponentRef<Viewer> = viewContainerRef.createComponent(componentFactory);
-    componentRef.instance.url = documentMetaData._links.binary.href;
+    componentRef.instance.url = this.urlFixer.fixDm(documentMetaData._links.binary.href);
     return componentRef.instance;
   }
 

--- a/src/app/utils/url-fixer.service.ts
+++ b/src/app/utils/url-fixer.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class UrlFixerService {
+  public fixDm(url: string): string {
+    return url.replace(/http.*\/documents\//, '/demproxy/dm/documents/');
+  }
+
+  public fixAnno(url: string): string {
+    return url.replace(/http.*\/annotation-sets\//, '/demproxy/an/annotation-sets/');
+  }
+}


### PR DESCRIPTION
Requests all go through the consuming service's backend but the URL for the doc may be an internal one so we just replace the TLD with `/demproxy` so it goes through the DM proxy on the Node layer.

At the moment we rewrite all URLs but hopefully we can remove that if the backend can serve up the HATEAOS links with the correct domain.